### PR TITLE
Fix minor typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ should be in the ballpark of Microsoft’s SafeInt, Chromium’s numerics, and w
 you could do by hand.
 
 Separate from run-time speed, adding integer overflow checks (as `trapping<T>`,
-`trapping_mul`, et c. do) increases object code size proportional to how many
+`trapping_mul`, etc. do) increases object code size proportional to how many
 checking call sites you have. `integers` aims to reduce the magnitude of the
 code size increase in `NDEBUG` builds. (Note the implementation in trap.h.)
 


### PR DESCRIPTION
Remove extra space in "etc" in Readme. 
Didn't open an issue because the typo was very minor.
> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR